### PR TITLE
Change to HUXt model initiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+#ignore files without extensions
+# Ignore all
+*
+# Unignore all with extensions
+!*.*
+# Unignore all dirs
+!*/
+
+
 # Compiled python modules.
 *.pyc
 

--- a/code/HUXt.py
+++ b/code/HUXt.py
@@ -428,8 +428,11 @@ class HUXt:
         elif not np.all(np.isnan(v_boundary)):
             assert v_boundary.size == 128
             self.v_boundary = v_boundary
-            # Set dummy number for cr_num
-            self.cr_num = 9999 * u.dimensionless_unscaled
+            if np.isnan(cr_num):
+                # Set dummy number for cr_num
+                self.cr_num = 9999 * u.dimensionless_unscaled
+            else:
+                self.cr_num = cr_num * u.dimensionless_unscaled
         elif not np.isnan(cr_num):
             # Find and load in the boundary condition file
             self.cr_num = cr_num * u.dimensionless_unscaled

--- a/code/HUXt.py
+++ b/code/HUXt.py
@@ -1442,7 +1442,7 @@ def map_v_inwards(v_outer, r_outer, lon_outer, r_inner):
     T_integral = term1 - term2
 
     # work out the longitudinal shift
-    phi_new = _zerototwopi_(lon_outer.value - (T_integral / Tsyn) * 2 * np.pi)
+    phi_new = _zerototwopi_(lon_outer.value + (T_integral / Tsyn) * 2 * np.pi)
 
     return v0*u.km/u.s, phi_new*u.rad
 

--- a/code/config.dat
+++ b/code/config.dat
@@ -1,4 +1,4 @@
-root,C:\Users\yq904481\research\repos\HUXt
+root,D:\Dropbox\python_repos\HUXt
 boundary_conditions,data\boundary_conditions
 ephemeris,data\ephemeris\ephemeris.hdf5
 HUXt_data,data\HUXt


### PR DESCRIPTION
Changed _init_ to allow a CR number to be specified alongside a user-defined longitudinal speed profile. This allows ephemeris information to be used.